### PR TITLE
Returns device ids from add_disk

### DIFF
--- a/vmm/src/api/http_endpoint.rs
+++ b/vmm/src/api/http_endpoint.rs
@@ -474,7 +474,14 @@ impl EndpointHandler for VmAddDisk {
                         match vm_add_disk(api_notifier, api_sender, Arc::new(vm_add_disk_data))
                             .map_err(HttpError::VmAddDisk)
                         {
-                            Ok(_) => Response::new(Version::Http11, StatusCode::NoContent),
+                            Ok(add_disk_info) => {
+                                let mut response = Response::new(Version::Http11, StatusCode::OK);
+                                let disk_info_serialized =
+                                    serde_json::to_string(&add_disk_info).unwrap();
+
+                                response.set_body(Body::new(disk_info_serialized));
+                                response
+                            }
                             Err(e) => error_response(e, StatusCode::InternalServerError),
                         }
                     }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -158,6 +158,11 @@ pub struct VmSnapshotConfig {
     pub destination_url: String,
 }
 
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AddDiskResponse {
+    pub disk_id: u32,
+}
+
 pub enum ApiResponsePayload {
     /// No data is sent on the channel.
     Empty,
@@ -168,8 +173,8 @@ pub enum ApiResponsePayload {
     /// Vmm ping response
     VmmPing(VmmPingResponse),
 
-    // id of recently added disk
-    DiskId(u32),
+    // info of added disk
+    DiskInfo(AddDiskResponse),
 }
 
 /// This is the response sent by the VMM API server through the mpsc channel.
@@ -473,7 +478,7 @@ pub fn vm_add_disk(
     api_evt: EventFd,
     api_sender: Sender<ApiRequest>,
     data: Arc<DiskConfig>,
-) -> ApiResult<()> {
+) -> ApiResult<AddDiskResponse> {
     let (response_sender, response_receiver) = channel();
 
     // Send the VM add-disk request.
@@ -482,9 +487,12 @@ pub fn vm_add_disk(
         .map_err(ApiError::RequestSend)?;
     api_evt.write(1).map_err(ApiError::EventFdWrite)?;
 
-    response_receiver.recv().map_err(ApiError::ResponseRecv)??;
+    let response = response_receiver.recv().map_err(ApiError::ResponseRecv)??;
 
-    Ok(())
+    match response {
+        ApiResponsePayload::DiskInfo(add_disk_info) => Ok(add_disk_info),
+        _ => Err(ApiError::ResponsePayloadType), // TODO@coder: this could be better across the project, cleanup
+    }
 }
 
 pub fn vm_add_pmem(

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -167,6 +167,9 @@ pub enum ApiResponsePayload {
 
     /// Vmm ping response
     VmmPing(VmmPingResponse),
+
+    // id of recently added disk
+    DiskId(u32),
 }
 
 /// This is the response sent by the VMM API server through the mpsc channel.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2074,7 +2074,7 @@ impl DeviceManager {
         &mut self,
         device: VirtioDeviceArc,
         iommu_attached: bool,
-    ) -> DeviceManagerResult<()> {
+    ) -> DeviceManagerResult<u32> {
         if iommu_attached {
             warn!("Placing device behind vIOMMU is not available for hotplugged devices");
         }
@@ -2097,11 +2097,12 @@ impl DeviceManager {
         // Update the PCIU bitmap
         self.pci_devices_up |= 1 << (device_id >> 3);
 
-        Ok(())
+        // @coder patch to get device ids
+        Ok(device_id)
     }
 
     #[cfg(feature = "pci_support")]
-    pub fn add_disk(&mut self, disk_cfg: &mut DiskConfig) -> DeviceManagerResult<()> {
+    pub fn add_disk(&mut self, disk_cfg: &mut DiskConfig) -> DeviceManagerResult<u32> {
         let (device, iommu_attached) = self.make_virtio_block_device(disk_cfg)?;
         self.hotplug_virtio_pci_device(device, iommu_attached)
     }
@@ -2109,13 +2110,15 @@ impl DeviceManager {
     #[cfg(feature = "pci_support")]
     pub fn add_pmem(&mut self, pmem_cfg: &mut PmemConfig) -> DeviceManagerResult<()> {
         let (device, iommu_attached) = self.make_virtio_pmem_device(pmem_cfg)?;
-        self.hotplug_virtio_pci_device(device, iommu_attached)
+        self.hotplug_virtio_pci_device(device, iommu_attached)?;
+        Ok(())
     }
 
     #[cfg(feature = "pci_support")]
     pub fn add_net(&mut self, net_cfg: &mut NetConfig) -> DeviceManagerResult<()> {
         let (device, iommu_attached) = self.make_virtio_net_device(net_cfg)?;
-        self.hotplug_virtio_pci_device(device, iommu_attached)
+        self.hotplug_virtio_pci_device(device, iommu_attached)?;
+        Ok(())
     }
 }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -17,7 +17,9 @@ extern crate tempfile;
 extern crate url;
 extern crate vmm_sys_util;
 
-use crate::api::{ApiError, ApiRequest, ApiResponse, ApiResponsePayload, VmInfo, VmmPingResponse};
+use crate::api::{
+    AddDiskResponse, ApiError, ApiRequest, ApiResponse, ApiResponsePayload, VmInfo, VmmPingResponse,
+};
 use crate::config::{DeviceConfig, DiskConfig, NetConfig, PmemConfig, RestoreConfig, VmConfig};
 use crate::migration::{recv_vm_snapshot, vm_config_from_snapshot};
 use crate::seccomp_filters::{get_seccomp_filter, Thread};
@@ -699,7 +701,11 @@ impl Vmm {
                                     let response = self
                                         .vm_add_disk(add_disk_data.as_ref().clone())
                                         .map_err(ApiError::VmAddDisk)
-                                        .map(|disk_id| ApiResponsePayload::DiskId(disk_id));
+                                        .map(|disk_id| {
+                                            ApiResponsePayload::DiskInfo(AddDiskResponse {
+                                                disk_id,
+                                            })
+                                        });
                                     sender.send(response).map_err(Error::ApiResponseSend)?;
                                 }
                                 ApiRequest::VmAddPmem(add_pmem_data, sender) => {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -731,15 +731,16 @@ impl Vm {
         }
     }
 
-    pub fn add_disk(&mut self, mut _disk_cfg: DiskConfig) -> Result<()> {
+    pub fn add_disk(&mut self, mut _disk_cfg: DiskConfig) -> Result<u32> {
         if cfg!(feature = "pci_support") {
             #[cfg(feature = "pci_support")]
             {
-                self.device_manager
+                let new_disk_id = self
+                    .device_manager
                     .lock()
                     .unwrap()
                     .add_disk(&mut _disk_cfg)
-                    .map_err(Error::DeviceManager)?;
+                    .map_err(Error::DeviceManager);
 
                 // Update VmConfig by adding the new device. This is important to
                 // ensure the device would be created in case of a reboot.
@@ -757,8 +758,9 @@ impl Vm {
                     .unwrap()
                     .notify_hotplug(HotPlugNotificationFlags::PCI_DEVICES_CHANGED)
                     .map_err(Error::DeviceManager)?;
+
+                new_disk_id
             }
-            Ok(())
         } else {
             Err(Error::NoPciSupport)
         }


### PR DESCRIPTION
Calls to the `PutVmAddDisk` http route return a json payload. 
Ex) `{ "disk_id": 45 }`